### PR TITLE
Replace const_fn with const_fn_trait_bound

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,6 @@
     unused_qualifications,
     missing_docs
 )]
-#![cfg_attr(feature = "nightly", feature(const_fn))]
 #![cfg_attr(feature = "docs-rs", feature(allocator_api))]
 
 use std::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@
     unused_qualifications,
     missing_docs
 )]
+#![cfg_attr(feature = "nightly", feature(const_fn_trait_bound))]
 #![cfg_attr(feature = "docs-rs", feature(allocator_api))]
 
 use std::{


### PR DESCRIPTION
As const functions were stabilized, `const_fn` feature was removed. But we need `const_fn_trait_bound`, because "trait bounds other than `Sized` on const fn parameters are unstable"