### PR TITLE
feat: peak memory usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ nightly = []
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "doc_cfg"]
+
+[dependencies]
+spin = { version = "0.9", default-features = false, features = [ "spin_mutex" ] }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,17 +1,27 @@
 extern crate stats_alloc;
 
-use stats_alloc::{Region, StatsAlloc, INSTRUMENTED_SYSTEM};
 use std::alloc::System;
+
+use stats_alloc::{Region, StatsAlloc, INSTRUMENTED_SYSTEM};
 
 #[global_allocator]
 static GLOBAL: &StatsAlloc<System> = &INSTRUMENTED_SYSTEM;
 
 #[test]
 fn example_using_region() {
-    let reg = Region::new(&GLOBAL);
+    let reg = Region::new(GLOBAL);
     let x: Vec<u8> = Vec::with_capacity(1_024);
     println!("Stats at 1: {:#?}", reg.change());
     // Used here to ensure that the value is not
     // dropped before we check the statistics
-    ::std::mem::size_of_val(&x);
+    let _ = ::std::mem::size_of_val(&x);
+}
+
+#[test]
+fn example_peak_mem_usage() {
+    let x: Vec<u8> = Vec::with_capacity(1_024);
+    println!("Stats at 1: {:#?}", GLOBAL.peak_mem_usage());
+    // Used here to ensure that the value is not
+    // dropped before we check the statistics
+    let _ = ::std::mem::size_of_val(&x);
 }


### PR DESCRIPTION
* track peak memory usage
* put all counters behind a `spin::Mutex`

While the current metrics allow to track how much bytes have been allocated/ reallocated/ deallocated it is not possible to infer how much memory was used simultaneously. This PR adds another counter `peak_mem_usage` in order to track the maximal value that `bytes_allocated - bytes_deallocated` ever had.
However, it seems to be not trivially possible to track this for a `Region` because it is possible that memory gets deallocated within the region that was allocated before the region started. This would lead to wrong results. For this reason `peak_mem_usage` gets exposed by `StatsAlloc` directly and not via `Region`.
It should however be possible to reset the peak_mem_usage to the current memory usage which basically forgets peaks in the past. This is what `peak_mem_usage_set_current` does.

The second commit wraps all counters in a `spin::Mutex` to fix #5. In case this is not desired I could also revert this commit.